### PR TITLE
ETA Fixes

### DIFF
--- a/passiogo/__init__.py
+++ b/passiogo/__init__.py
@@ -569,7 +569,7 @@ class Route:
 	
 	def __init__(
 		self,
-		id: str,
+		id: int,
 		groupId: int = None,
 		groupColor: str = None,
 		name: str = None,

--- a/passiogo/__init__.py
+++ b/passiogo/__init__.py
@@ -686,8 +686,7 @@ class Stop:
 		if not etas:
 			return None
 
-		# Generally operates in O(1) as etas come sorted by API
-		return min(etas, key = lambda x : x[0])
+		return etas[0]
 
 	def getEtas(
 			self,
@@ -715,7 +714,7 @@ class Stop:
 					eta = convertToUnixEta(vehicle["secondsSpent"])
 				else:
 					eta = vehicle["secondsSpent"]
-			vehicles.append((eta, self.system.getVehicleById(int(vehicle["busId"]))))
+				vehicles.append((eta, self.system.getVehicleById(int(vehicle["busId"]))))
 		return vehicles
 	
 

--- a/passiogo/__init__.py
+++ b/passiogo/__init__.py
@@ -709,7 +709,7 @@ class Stop:
 		if str(self.id) not in data:
 			return vehicles
 		for vehicle in data[str(self.id)]:
-			if vehicle["etaR"]: #etaR is "" when eta is unavailable
+			if "etaR" in vehicle and vehicle["etaR"]: #etaR is "" when eta is unavailable
 				if returnInUTC:
 					eta = convertToUnixEta(vehicle["secondsSpent"])
 				else:


### PR DESCRIPTION
I've created a PR for fixing issues found during implementation of testing after #25. So far I have fixed a missing indent that caused ```Stop.getEtas()``` to reference ```eta``` without one existing, as well as stops with no vehicles having no ```etaR``` field and therefore causing a key error.

Finally, I removed my incorrect comment about ```min()``` and opted for the more efficient solution. However, the ```Stop.getNextVehicle()``` method now doesn't serve much purpose as users can just do this simple operation on their own.