### PR TITLE
fix latitude and longitude for Vehicle class

### DIFF
--- a/passiogo/__init__.py
+++ b/passiogo/__init__.py
@@ -683,7 +683,8 @@ class Vehicle:
 		self.routeName = routeName
 		self.color = color
 		self.created = created
-		self.longitude = latitude
+		self.longitude = longitude
+		self.latitude = latitude
 		self.speed = speed
 		self.paxLoad = paxLoad
 		self.outOfService = outOfService


### PR DESCRIPTION
the latitude and longitude for the vehicle class was wrong. it's an easy fix though.